### PR TITLE
add container options. Set default container to body instead of parent's element.

### DIFF
--- a/tooltip/src/main/java/com/arcbees/gquery/tooltip/client/TooltipImpl.java
+++ b/tooltip/src/main/java/com/arcbees/gquery/tooltip/client/TooltipImpl.java
@@ -226,8 +226,13 @@ public class TooltipImpl {
                 .removeClass("in", "top", "bottom", "left", "right")
                 .css("top", "0")
                 .css("left", "0")
-                .css("display", "block")
-                .insertAfter($element);
+                .css("display", "block");
+
+        if (options.getContainer() != null && options.getContainer().length() > 0) {
+            tooltip.appendTo($(options.getContainer()));
+        } else {
+            tooltip.insertAfter($element);
+        }
 
         OffsetInfo oi = OffsetInfo.from($element);
         long actualWidth = tooltip.get(0).getOffsetWidth();

--- a/tooltip/src/main/java/com/arcbees/gquery/tooltip/client/TooltipOptions.java
+++ b/tooltip/src/main/java/com/arcbees/gquery/tooltip/client/TooltipOptions.java
@@ -18,6 +18,7 @@ public class TooltipOptions {
     }
 
     private static boolean globalAnimation;
+    private static String globalContainer;
     private static String globalContent;
     private static TooltipContentProvider globalContentProvider;
     private static int globalDelayShow;
@@ -31,6 +32,10 @@ public class TooltipOptions {
 
     public static void setGlobalAnimation(boolean globalAnimation) {
         TooltipOptions.globalAnimation = globalAnimation;
+    }
+
+    public static void setGlobalContainer(String globalContainer) {
+        TooltipOptions.globalContainer = globalContainer;
     }
 
     public static void setGlobalContent(String globalContent) {
@@ -80,9 +85,11 @@ public class TooltipOptions {
         globalPlacement = TooltipPlacement.TOP;
         globalTrigger = TooltipTrigger.HOVER;
         globalDelayShow = globalDelayHide = 0;
+        globalContainer = "body";
     }
 
     private Boolean animation;
+    private String container;
     private String content;
     private TooltipContentProvider contentProvider;
     private Integer delayShow;
@@ -104,12 +111,17 @@ public class TooltipOptions {
             placement = options.getPlacement();
             selector = options.getSelector();
             content = options.getContent();
+            container = options.getContainer();
             contentProvider = options.getContentProvider();
             trigger = options.getTrigger();
             delayShow = options.getDelayShow();
             delayHide = options.getDelayHide();
             resources = options.getResources();
         }
+    }
+
+    public String getContainer() {
+        return container != null ? container : globalContainer;
     }
 
     public String getContent() {
@@ -163,6 +175,17 @@ public class TooltipOptions {
      */
     public TooltipOptions withAnimation(boolean animation) {
         this.animation = animation;
+        return this;
+    }
+
+    /**
+     * css selector defining the container where the tooltip will be appended. If the container is null (or empty
+     * string, the tooltip will be added after the element targeted by the tooltip.
+     *
+     * @param container
+     */
+    public TooltipOptions withContainer(String container) {
+        this.container = container;
         return this;
     }
 


### PR DESCRIPTION
Before this patch we appended the tooltip element in the parent. If the parent had the css property overflow set to the value hidden or auto, the tooltip was not displayed. 
I add a container option so that the user can specified where the tooltip has to be appended. By default (can be discussed), the container is the body element.  
