### PR TITLE
Fis issue of flashing tooltip when content is a widget

### DIFF
--- a/tooltip/src/main/java/com/arcbees/gquery/tooltip/client/TooltipImpl.java
+++ b/tooltip/src/main/java/com/arcbees/gquery/tooltip/client/TooltipImpl.java
@@ -258,7 +258,8 @@ public class TooltipImpl {
                 .removeClass(style.in(), style.top(), style.bottom(), style.left(), style.right())
                 .css("top", "0")
                 .css("left", "0")
-                .css("display", "block");
+                .css("display", "block")
+                .css("visibility", "hidden");
 
         String container = options.getContainer();
 
@@ -342,6 +343,7 @@ public class TooltipImpl {
         tooltip.offset((int) finalTop, (int) finalLeft);
         tooltip.addClass(placementClass)
                 .addClass(style.in());
+        tooltip.css("visibility", "visible");
 
         if (options.getTrigger() == TooltipTrigger.CLICK && options.isAutoClose()) {
             $(document).delay(1, new Function() {


### PR DESCRIPTION
When the content is a widget, we use a ScheduledCommand to position and show the tooltip. During the time the command is executed, the tooltip can be displayed temporary in the wrong place.
